### PR TITLE
Fix the bug in the searching feature

### DIFF
--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/community/CommunityEventFragment.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/community/CommunityEventFragment.kt
@@ -107,21 +107,14 @@ class CommunityEventFragment : Fragment() {
 
         Log.d(ContentValues.TAG, "Community onViewCreated start")
         if (Firebase.auth.currentUser == null) {
-            val progressBar = view?.findViewById<ProgressBar>(R.id.progressBar)
+            val progressBar = view.findViewById<ProgressBar>(R.id.progressBar)
+            val textView = view.findViewById<LinearLayout>(R.id.root).findViewById<TextView>(R.id.text_view)
             progressBar?.visibility = View.GONE
-            val layout = view.findViewById<LinearLayout>(R.id.root)
-            val textView = TextView(context)
-            //setting height and width
-            textView.layoutParams = LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            textView.visibility = View.VISIBLE
             textView.text = "Events are only available for logged in Users"
-            textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20f)
-            textView.setTextColor(Color.GRAY)
-            textView.setPadding(20, 20, 20, 20)
-            textView.textAlignment = TextView.TEXT_ALIGNMENT_CENTER
-            textView.gravity = Gravity.CENTER_VERTICAL
-            textView.isAllCaps=false
-            layout?.addView(textView)
+            //val layout = view.findViewById<LinearLayout>(R.id.root)
+            //val textView = createTextView("Events are only available for logged in Users")
+            //layout?.addView(textView)
         }
         else{
             val bottomSheetView = view.findViewById<LinearLayout>(R.id.bottomLayout)
@@ -167,6 +160,21 @@ class CommunityEventFragment : Fragment() {
             )
 
         }
+    }
+
+    private fun createTextView(text: String): TextView {
+        val textView = TextView(context)
+        //setting height and width
+        textView.layoutParams = LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        textView.text = text
+        textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20f)
+        textView.setTextColor(Color.GRAY)
+        textView.setPadding(20, 20, 20, 20)
+        textView.textAlignment = TextView.TEXT_ALIGNMENT_CENTER
+        textView.gravity = Gravity.CENTER_VERTICAL
+        textView.isAllCaps=false
+        return textView
     }
 
     private fun setUpSearchView(searchView: SearchView) {
@@ -278,15 +286,31 @@ class CommunityEventFragment : Fragment() {
         inputText: String
     ) {
         val progressBar = view?.findViewById<ProgressBar>(R.id.progressBar)
+        val textView = view?.findViewById<LinearLayout>(R.id.root)?.findViewById<TextView>(R.id.text_view)
         eventDataAdapter.refresh(
             inputText = inputText,
             query = query,
             showProgressBar = {
                 progressBar?.visibility = View.VISIBLE
+            },
+            onNoResults = {
+                progressBar?.visibility = View.GONE
+                textView?.visibility = View.VISIBLE
+                textView?.text = "No results were found"
+                /*
+                val layout = view?.findViewById<LinearLayout>(R.id.root)
+                val textView = createTextView("No results were found")
+                val recyclerView = view?.findViewById<RecyclerView>(R.id.recyclerCommunity)
+                recyclerView?.visibility = View.GONE
+                layout?.addView(textView)
+
+                 */
             }
         ) {
+            textView?.visibility = View.GONE
             progressBar?.visibility = View.GONE
             val recyclerView = view?.findViewById<RecyclerView>(R.id.recyclerCommunity)
+            recyclerView?.visibility = View.VISIBLE
             recyclerView?.layoutManager = LinearLayoutManager(view?.context)
             recyclerView?.adapter = CommunityRecyclerAdapter(eventDataAdapter)
             val textViewTitle: TextView = bottomSheetView.findViewById<TextView>(R.id.textViewCommunityTitle)

--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/community/data/EventDataAdapter.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/community/data/EventDataAdapter.kt
@@ -165,6 +165,7 @@ class EventDataAdapter {
         inputText: String,
         query: Query,
         showProgressBar: () -> Unit,
+        onNoResults: () -> Unit,
         onComplete: () -> Unit,
     ) {
         showProgressBar()
@@ -278,9 +279,9 @@ class EventDataAdapter {
                     refreshedLikedEvents {
                         onComplete()
                     }
+                }else {
+                    onNoResults()
                 }
-
-
 
             }.addOnFailureListener { exception ->
                 Log.d("query", "refresh failed: $exception")

--- a/app/src/main/res/layout/fragment_community_event.xml
+++ b/app/src/main/res/layout/fragment_community_event.xml
@@ -24,6 +24,20 @@
             android:background="@drawable/rounded_bar"
             app:iconifiedByDefault="false"/>
 
+        <TextView
+            android:id="@+id/text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textSize="20sp"
+            android:textColor="@color/gray"
+            android:padding="20dp"
+            android:textAlignment="center"
+            android:gravity="center"
+            android:textAllCaps="false"
+            android:layout_gravity="center"
+            tools:text="no results were found"/>
+
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="wrap_content">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -23,4 +23,5 @@
     <color name="dark_green">#002925</color>
     <color name="forget_blue">#007AFF</color>
     <color name="red">#C51717</color>
+    <color name="gray">#FF888888</color>
 </resources>


### PR DESCRIPTION
issue: When there are no results after users type keywords in the search bar, the progress bar will continue to be visible, and the results in the event list will either be blank or unchanged. It is intended to display hints, letting users know that there are no results.

Fixed the issue: The progress bar is invisible, and hints are displayed to let users know that there are no results.