### PR TITLE
Added Sticky Header for Events list

### DIFF
--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/community/CommunityEventFragment.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/community/CommunityEventFragment.kt
@@ -257,7 +257,7 @@ class CommunityEventFragment : Fragment(), AdapterView.OnItemSelectedListener {/
         searchView.setIconifiedByDefault(false)
         searchView.isSubmitButtonEnabled = true
         searchView.imeOptions = EditorInfo.IME_ACTION_SEARCH
-        searchView.queryHint = "search events"
+        searchView.queryHint = "search"
 
     }
 
@@ -374,10 +374,16 @@ class CommunityEventFragment : Fragment(), AdapterView.OnItemSelectedListener {/
         ) {
             textView?.visibility = View.GONE
             progressBar?.visibility = View.GONE
-            val recyclerView = view?.findViewById<RecyclerView>(R.id.recyclerCommunity)
-            recyclerView?.visibility = View.VISIBLE
-            recyclerView?.layoutManager = LinearLayoutManager(view?.context)
-            recyclerView?.adapter = CommunityRecyclerAdapter(eventDataAdapter)
+            val recyclerView = view?.findViewById<RecyclerView>(R.id.recyclerCommunity)!!
+            val communityRecyclerAdapter = CommunityRecyclerAdapter(eventDataAdapter)
+            recyclerView.visibility = View.VISIBLE
+            recyclerView.layoutManager = LinearLayoutManager(view?.context)
+            recyclerView.adapter = communityRecyclerAdapter
+            recyclerView.addItemDecoration(LinePaint())
+
+            val stickyHeaderItemDecorator = StickyHeaderItemDecorator(communityRecyclerAdapter)
+            recyclerView.addItemDecoration(stickyHeaderItemDecorator)
+
             val textViewTitle: TextView = bottomSheetView.findViewById<TextView>(R.id.textViewCommunityTitle)
             val textViewCommunityLocation: TextView =bottomSheetView.findViewById<TextView>(R.id.textViewCommunityLocation)
             val textViewCommunityTime: TextView =bottomSheetView.findViewById<TextView>(R.id.textViewCommunityTime)
@@ -398,7 +404,7 @@ class CommunityEventFragment : Fragment(), AdapterView.OnItemSelectedListener {/
                 )
             }
 
-            (recyclerView?.adapter as CommunityRecyclerAdapter).setClickListener(object :
+            (recyclerView.adapter as CommunityRecyclerAdapter).setClickListener(object :
                 CommunityRecyclerAdapter.ClickListener {
                 @SuppressLint("ResourceAsColor")
                 override fun onClick(event: Event, position: Int) {
@@ -452,7 +458,7 @@ class CommunityEventFragment : Fragment(), AdapterView.OnItemSelectedListener {/
 
                         eventDataAdapter.setLikedEvent(event){ event ->
                             refreshBottomSheet(event, relativeLayoutImage, textInterested, imageViewUnFav, buttonInterested)
-                            (recyclerView?.adapter as CommunityRecyclerAdapter).notifyItemChanged(position)
+                            (recyclerView.adapter as CommunityRecyclerAdapter).notifyItemChanged(position)
                             Log.d("Liked Event Firebase Update", "Liked Event Firebase Update Success")
                         }
                     }
@@ -463,7 +469,7 @@ class CommunityEventFragment : Fragment(), AdapterView.OnItemSelectedListener {/
                 }
             })
 
-            recyclerView!!.addItemDecoration(LinePaint())
+            //recyclerView!!.addItemDecoration(LinePaint())
             var changedType: String? = null
             var eventId: String? = null
             var eventTitle: String = "unknown event"

--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/community/StickyHeaderInterface.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/community/StickyHeaderInterface.kt
@@ -1,0 +1,34 @@
+package org.brightmindenrichment.street_care.ui.community
+
+import android.view.View
+
+interface StickyHeaderInterface {
+    /**
+     * This method gets called by [StickHeaderItemDecoration] to fetch the position of the header item in the adapter
+     * that is used for (represents) item at specified position.
+     * @param itemPosition int. Adapter's position of the item for which to do the search of the position of the header item.
+     * @return int. Position of the header item in the adapter.
+     */
+    fun getHeaderPositionForItem(itemPosition: Int): Int
+
+    /**
+     * This method gets called by [StickHeaderItemDecoration] to get layout resource id for the header item at specified adapter's position.
+     * @param headerPosition int. Position of the header item in the adapter.
+     * @return int. Layout resource id.
+     */
+    fun getHeaderLayout(headerPosition: Int): Int
+
+    /**
+     * This method gets called by [StickHeaderItemDecoration] to setup the header View.
+     * @param header View. Header to set the data on.
+     * @param headerPosition int. Position of the header item in the adapter.
+     */
+    fun bindHeaderData(header: View?, headerPosition: Int)
+
+    /**
+     * This method gets called by [StickHeaderItemDecoration] to verify whether the item represents a header.
+     * @param itemPosition int.
+     * @return true, if item at the specified adapter's position represents a header.
+     */
+    fun isHeader(itemPosition: Int): Boolean
+}

--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/community/StickyHeaderItemDecorator.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/community/StickyHeaderItemDecorator.kt
@@ -1,0 +1,132 @@
+package org.brightmindenrichment.street_care.ui.community
+
+import android.graphics.Canvas
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+
+class StickyHeaderItemDecorator(
+    private val mListener: StickyHeaderInterface,
+) : RecyclerView.ItemDecoration() {
+    private var mStickyHeaderHeight = 0
+
+    override fun onDrawOver(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
+        super.onDrawOver(canvas, parent, state)
+        val topChild = parent.getChildAt(0) ?: run {
+            Log.d("stickyHeader", "topChild is null")
+            return
+        }
+        val topChildPosition = parent.getChildAdapterPosition(topChild)
+        if (topChildPosition == RecyclerView.NO_POSITION) {
+            Log.d("stickyHeader", "No Position. $topChildPosition")
+            return
+        }
+        val headerPos = mListener.getHeaderPositionForItem(topChildPosition)
+        val currentHeader = getHeaderViewForItem(headerPos, parent)
+        fixLayoutSize(parent, currentHeader)
+        val contactPoint = currentHeader.bottom
+        val childInContact = getChildInContact(parent, contactPoint, headerPos)
+        if ((childInContact != null) &&
+            mListener.isHeader(parent.getChildAdapterPosition(childInContact))
+        ) {
+            moveHeader(canvas, currentHeader, childInContact)
+            Log.d("stickyHeader", "moveHeader")
+            return
+        }
+        Log.d("stickyHeader", "drawHeader")
+        drawHeader(canvas, currentHeader)
+    }
+
+    private fun getHeaderViewForItem(headerPosition: Int, parent: RecyclerView): View {
+        val layoutResId = mListener.getHeaderLayout(headerPosition)
+        val header = LayoutInflater.from(parent.context).inflate(layoutResId, parent, false)
+        //Log.d("stickyHeader", "before header: ${header.findViewById<TextView>(R.id.textViewCommunityYear).text} ")
+        mListener.bindHeaderData(header, headerPosition)
+        //Log.d("stickyHeader", "after header: ${header.findViewById<TextView>(R.id.textViewCommunityYear).text} ")
+
+        return header
+    }
+
+    private fun drawHeader(c: Canvas, header: View) {
+        c.save()
+        c.translate(0f, 0f)
+        header.draw(c)
+        c.restore()
+    }
+
+    private fun moveHeader(c: Canvas, currentHeader: View, nextHeader: View) {
+        c.save()
+        c.translate(0f, (nextHeader.top - currentHeader.height).toFloat())
+        currentHeader.draw(c)
+        c.restore()
+    }
+
+    private fun getChildInContact(
+        parent: RecyclerView,
+        contactPoint: Int,
+        currentHeaderPos: Int
+    ): View? {
+        var childInContact: View? = null
+        for (i in 0 until parent.childCount) {
+            var heightTolerance = 0
+            val child = parent.getChildAt(i)
+
+            //measure height tolerance with child if child is another header
+            if (currentHeaderPos != i) {
+                val isChildHeader = mListener.isHeader(parent.getChildAdapterPosition(child))
+                if (isChildHeader) {
+                    heightTolerance = mStickyHeaderHeight - child.height
+                }
+            }
+
+            //add heightTolerance if child top be in display area
+            val childBottomPosition: Int = if (child.top > 0) {
+                child.bottom + heightTolerance
+            } else {
+                child.bottom
+            }
+            if (childBottomPosition > contactPoint) {
+                if (child.top <= contactPoint) {
+                    // This child overlaps the contactPoint
+                    childInContact = child
+                    break
+                }
+            }
+        }
+        return childInContact
+    }
+
+
+    /**
+     * Properly measures and layouts the top sticky header.
+     * @param parent ViewGroup: RecyclerView in this case.
+     */
+    private fun fixLayoutSize(parent: ViewGroup, view: View) {
+
+        // Specs for parent (RecyclerView)
+        val widthSpec = View.MeasureSpec.makeMeasureSpec(parent.width, View.MeasureSpec.EXACTLY)
+        val heightSpec =
+            View.MeasureSpec.makeMeasureSpec(parent.height, View.MeasureSpec.UNSPECIFIED)
+
+        // Specs for children (headers)
+        val childWidthSpec = ViewGroup.getChildMeasureSpec(
+            widthSpec,
+            parent.paddingLeft + parent.paddingRight,
+            view.layoutParams.width
+        )
+        val childHeightSpec = ViewGroup.getChildMeasureSpec(
+            heightSpec,
+            parent.paddingTop + parent.paddingBottom,
+            view.layoutParams.height
+        )
+        view.measure(childWidthSpec, childHeightSpec)
+        view.layout(0, 0, view.measuredWidth, view.measuredHeight.also {
+            mStickyHeaderHeight = it
+            //Log.d("stickyHeader", "mStickyHeaderHeight: $mStickyHeaderHeight")
+        })
+    }
+
+}

--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/community/adapter/CommunityRecyclerAdapter.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/community/adapter/CommunityRecyclerAdapter.kt
@@ -15,13 +15,17 @@ import androidx.recyclerview.widget.RecyclerView
 import com.squareup.picasso.Picasso
 import de.hdodenhof.circleimageview.CircleImageView
 import org.brightmindenrichment.street_care.R
+import org.brightmindenrichment.street_care.ui.community.StickyHeaderInterface
 import org.brightmindenrichment.street_care.ui.community.data.CommunityData
 import org.brightmindenrichment.street_care.ui.community.data.Event
 import org.brightmindenrichment.street_care.ui.community.data.EventDataAdapter
 import org.brightmindenrichment.street_care.util.Extensions
 
+
+
+
 class CommunityRecyclerAdapter(private val controller: EventDataAdapter) :
-    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    RecyclerView.Adapter<RecyclerView.ViewHolder>(), StickyHeaderInterface {
 
     interface ClickListener {
         fun onClick(event: Event, position: Int){}
@@ -54,6 +58,12 @@ class CommunityRecyclerAdapter(private val controller: EventDataAdapter) :
 
     fun clickItem(event: Event, pos: Int) {
         clickListener!!.onClick(event, pos)
+    }
+
+    private var currentHeaderText: String? = null
+
+    fun getCurrentHeaderText(): String? {
+        return currentHeaderText
     }
 
 
@@ -205,14 +215,15 @@ class CommunityRecyclerAdapter(private val controller: EventDataAdapter) :
 
     inner class YearViewHolder (yearItemView: View) : RecyclerView.ViewHolder(yearItemView){
         private val textViewYear: TextView = yearItemView.findViewById<TextView>(R.id.textViewCommunityYear)
-
         fun bind(pos: Int) {
             // Bind data to views
             // ...
             val communityData = controller.getEventAtPosition(pos)
             communityData?.eventYear?.let{ eventYear->
                 textViewYear.text = eventYear.year
+                currentHeaderText = eventYear.year
             }
+            //Log.d("stickyHeader", "pos: $pos, textViewYear: ${textViewYear.text}")
         }
 
     }
@@ -253,4 +264,32 @@ class CommunityRecyclerAdapter(private val controller: EventDataAdapter) :
         }
     }
 
+    override fun getHeaderPositionForItem(itemPosition: Int): Int {
+        var headerPosition = 0
+        var theItemPosition = itemPosition
+        do {
+            if (isHeader(theItemPosition)) {
+                headerPosition = theItemPosition
+                break
+            }
+            theItemPosition -= 1
+        } while (theItemPosition >= 0)
+        return headerPosition
     }
+
+    override fun getHeaderLayout(headerPosition: Int): Int {
+        return R.layout.card_community_year
+    }
+
+    override fun bindHeaderData(header: View?, headerPosition: Int) {
+        header?.let{
+            it.findViewById<TextView>(R.id.textViewCommunityYear).text = controller.getEventAtPosition(headerPosition)?.eventYear?.year
+            it.findViewById<TextView>(R.id.textViewCommunityYear).setBackgroundColor(Color.WHITE)
+        }
+    }
+
+    override fun isHeader(itemPosition: Int): Boolean {
+        return controller.getEventAtPosition(itemPosition)?.layoutType == Extensions.TYPE_MONTH
+    }
+
+}

--- a/app/src/main/res/layout/card_community_year.xml
+++ b/app/src/main/res/layout/card_community_year.xml
@@ -9,7 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintTop_toTopOf="parent"
-        android:textSize="15dp"
+        android:textSize="15sp"
         android:textColor="@color/black"
         android:padding="10dp"
         android:textStyle="bold"

--- a/app/src/main/res/layout/fragment_community_event.xml
+++ b/app/src/main/res/layout/fragment_community_event.xml
@@ -80,6 +80,12 @@
             android:layout_gravity="center"
             tools:text="no results were found"/>
 
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerCommunity"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <!--
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
@@ -88,6 +94,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
         </ScrollView>
+        -->
     </LinearLayout>
 
     <ProgressBar


### PR DESCRIPTION
Implemented sticky header for the events recycler view, ensuring that the month and year remain fixed at the top during scrolling.