### PR TITLE
Icon title

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -29,6 +29,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="4dp"
         android:background="?android:attr/windowBackground"
+        app:labelVisibilityMode="labeled"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"


### PR DESCRIPTION
in the Android version, the title is only visible when the user is on the
specific page associated with that icon, and it becomes invisible when navigating to other
pages.

