### PR TITLE
fix truncated menu titles

### DIFF
--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -11,7 +11,7 @@
         <item
             android:id="@+id/nav_visit"
             android:icon="@drawable/ic_visit_log"
-            android:title="@string/visit_log" />
+            android:title="@string/menu_visit" />
 
         <item
             android:id="@+id/nav_community"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -52,7 +52,7 @@
     <string name="mental_illness">Falta de Hogar y Enfermedades Mentales</string>
 
     <string name="menu_home">Cómo Ayudar</string>
-    <string name="menu_visit">Registro de Visitas</string>
+    <string name="menu_visit">Visitas</string>
     <string name="menu_community">Comunidad</string>
     <string name="menu_profile">Perfil</string>
 


### PR DESCRIPTION
Change the app language to Spanish mode and the menu titles for the visit log are truncated. This fixes that

Docs for changing an app's language to Spanish
https://support.google.com/android/answer/12395118?hl=en 
