### PR TITLE
orderBy createdAt sort on helpRequests

### DIFF
--- a/app/src/main/java/org/brightmindenrichment/street_care/util/Queries.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/util/Queries.kt
@@ -25,6 +25,7 @@ object Queries {
     ): Query {
         return Firebase.firestore
             .collection("helpRequests")
+            .orderBy("createdAt", order)
     }
 
     fun getPastEventsQuery(

--- a/app/src/main/java/org/brightmindenrichment/street_care/util/Queries.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/util/Queries.kt
@@ -25,7 +25,6 @@ object Queries {
     ): Query {
         return Firebase.firestore
             .collection("helpRequests")
-            .orderBy("title", order)
     }
 
     fun getPastEventsQuery(


### PR DESCRIPTION
remove orderBy sort on helpRequests query to sync feature parity with iOS

![image](https://github.com/user-attachments/assets/c4f84d05-ab33-4652-8684-931123bcc1c8)
