### PR TITLE
refactor banner data fetch from firebase

### DIFF
--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/home/HomeFragment.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/home/HomeFragment.kt
@@ -7,9 +7,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
-import android.widget.Toast
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.slider.Slider
 import org.brightmindenrichment.street_care.R
@@ -38,14 +37,13 @@ class HomeFragment : Fragment() {
     // Verification-Banner
     private lateinit var verificationBanner: View
 
+    private val homeViewModel: HomeViewModel by viewModels()
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val homeViewModel =
-            ViewModelProvider(this).get(HomeViewModel::class.java)
-
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
         val root: View = binding.root
         includedLayout = binding.cardHomeFragment
@@ -59,7 +57,10 @@ class HomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         // setupBanner call
-        setupBanner()
+        homeViewModel.fetchBannerData()
+        homeViewModel.bannerData.observe(viewLifecycleOwner) { bannerData ->
+            if (bannerData != null) setupBanner(bannerData)
+        }
         setUpSliderImagesView()
 
 
@@ -104,11 +105,20 @@ class HomeFragment : Fragment() {
     }
 
     // Banner function
-    private fun setupBanner() {
-        if (isBannerDismissed) {
+    private fun setupBanner(bannerData: BannerData) {
+        var shouldShowBanner = !isBannerDismissed
+        if (!shouldShowBanner) {
             verificationBanner.visibility = View.GONE
         } else {
-            verificationBanner.visibility = View.VISIBLE
+            with(binding.verificationBanner) {
+                with(bannerData) {
+                    shouldShowBanner = body.isNotEmpty()
+                    tvBannerHeader.text = header
+                    tvBannerSubHeader.text = subHeader
+                    tvBannerBody.text = body
+                }
+            }
+            if (shouldShowBanner) verificationBanner.visibility = View.VISIBLE
 
             // Set up close button
             verificationBanner.findViewById<ImageButton>(R.id.btn_close).setOnClickListener {

--- a/app/src/main/java/org/brightmindenrichment/street_care/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/ui/home/HomeViewModel.kt
@@ -1,13 +1,41 @@
 package org.brightmindenrichment.street_care.ui.home
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.google.firebase.firestore.FirebaseFirestore
+import java.util.Locale
+
+fun isAppLanguageSpanish(): Boolean {
+    val currentLanguage = Locale.getDefault().language
+    return currentLanguage.startsWith("es")
+}
+
+data class BannerData(val header: String = "", val subHeader: String = "", val body: String = "")
 
 class HomeViewModel : ViewModel() {
 
-    private val _text = MutableLiveData<String>().apply {
-        value = "This is home Fragment"
+    private val _bannerData = MutableLiveData<BannerData?>()
+    val bannerData: MutableLiveData<BannerData?> = _bannerData
+    fun fetchBannerData() {
+        FirebaseFirestore.getInstance().collection("page_content")
+            .document(if (isAppLanguageSpanish()) "banner_data_es" else "banner_data").get()
+            .addOnSuccessListener { documentSnapshot ->
+                val bannerBody = documentSnapshot.data?.get("body") as String?
+                if (documentSnapshot.data != null && !bannerBody.isNullOrEmpty()) {
+                    with(documentSnapshot.data!!) {
+                        _bannerData.value = BannerData(
+                            header = this["header"] as String? ?: "",
+                            subHeader = this["sub_header"] as String? ?: "",
+                            body = bannerBody
+                        )
+                    }
+                }
+            }.addOnFailureListener { exception ->
+                _bannerData.value = null
+                Log.w("BME", "Banner data failed to fetch data from Database $exception")
+            }
+
     }
-    val text: LiveData<String> = _text
 }

--- a/app/src/main/res/layout/banner_verification.xml
+++ b/app/src/main/res/layout/banner_verification.xml
@@ -15,7 +15,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="12dp"
-        tools:text="COMING SOON"
+        tools:text="lorem ipsum headline"
         android:textColor="@color/com_facebook_blue"
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/banner_verification.xml
+++ b/app/src/main/res/layout/banner_verification.xml
@@ -1,53 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/banner_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/banner_yellow"
-    android:visibility="visible">
+    tools:visibility="visible"
+    android:visibility="gone">
 
     <TextView
-        android:id="@+id/tv_coming_soon"
+        android:id="@+id/tv_banner_header"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="12dp"
-        android:text="@string/banner_coming_soon"
+        tools:text="COMING SOON"
         android:textColor="@color/com_facebook_blue"
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/tv_get_verified"
+        android:id="@+id/tv_banner_sub_header"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="4dp"
-        android:text="@string/banner_get_verified"
+        tools:text="Get Verified!"
         android:textColor="@color/black"
         android:textStyle="bold"
         android:textFontWeight="900"
         android:textSize="16sp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_coming_soon" />
+        app:layout_constraintTop_toBottomOf="@id/tv_banner_header" />
 
     <TextView
-        android:id="@+id/tv_description"
+        android:id="@+id/tv_banner_body"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="4dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:text="@string/verification_banner"
+        tools:text="Profile verification will allow anyone who is verified to post upcoming events and document their interactions with homeless individuals."
         android:textColor="@color/black"
         android:lineSpacingExtra="2dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_get_verified" />
+        app:layout_constraintTop_toBottomOf="@id/tv_banner_sub_header" />
 
     <ImageButton
         android:id="@+id/btn_close"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -32,11 +32,6 @@ Si prefieres firmar y enviar una copia o guardarla para referencia futura, por f
     <string name="howtohelp_what_to_bring">Qué Llevar y Dar</string>
     <string name="donate">Donar</string>
 
-    <!-- Home/ Verification Banner -->
-    <string name="verification_banner">La verificación del perfil permitirá a cualquier persona verificada publicar próximos eventos y documentar sus interacciones con personas sin hogar.</string>
-    <string name="banner_get_verified">¡Verifícate!</string>
-    <string name="banner_coming_soon">PRÓXIMAMENTE</string>
-
     <string name="before">Antes del alcance</string>
     <string name="before_desc">Las personas sin hogar son un grupo diverso de personas como todos los demás, sin importar su apariencia, género, edad o raza.</string>
     <string name="before_desc_2">Algunos han caído en tiempos difíciles. Algunos pueden estar luchando con enfermedades mentales. Pero todos quieren ser tratados con respeto y dignidad.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,11 +36,6 @@
     <string name="howtohelp_what_to_bring">What to Bring and Give</string>
     <string name="donate">Donate</string>
 
-    <!-- Home/ Verification Banner -->
-    <string name="verification_banner">Profile verification will allow anyone who is verified to post upcoming events and document their interactions with homeless individuals.</string>
-    <string name="banner_get_verified">Get verified!</string>
-    <string name="banner_coming_soon">COMING SOON</string>
-
     <string name="before">Before outreach</string>
     <string name="before_desc">Homeless people are a diverse group of individuals just like everyone else, no matter their appearance, gender, age, or race.</string>
     <string name="before_desc_2">Some have fallen on hard times. Some may be struggling with mental illness. But everyone wants to be treated with respect and dignity.</string>


### PR DESCRIPTION
Fetching content for banner view from Firebase to enable dynamic server driven content. Added a check for spanish localization and check for null body description to control overall banner visibility. Connected live data and viewModel to fragment

Spanish
<img width="362" alt="image" src="https://github.com/user-attachments/assets/6e564f20-b158-463c-b2e4-fa2ec43f513f" />

English
<img width="356" alt="image" src="https://github.com/user-attachments/assets/3fb7fb0c-59ca-48e8-8476-e43ad48972eb" />
