### PR TITLE
Display approved past events only

### DIFF
--- a/app/src/main/java/org/brightmindenrichment/street_care/util/Queries.kt
+++ b/app/src/main/java/org/brightmindenrichment/street_care/util/Queries.kt
@@ -38,6 +38,7 @@ object Queries {
         val targetDay = Timestamp(Date(System.currentTimeMillis()))
         return Firebase.firestore
             .collection("outreachEventsDev")
+            .whereEqualTo("status","approved")
             .whereLessThan("eventDate", targetDay)
             .orderBy("eventDate", order)
     }


### PR DESCRIPTION
For past outreach events in community tab, display only those events whose status is approved.

**Without status approval: Aug 19th "test past event"**
<img width="960" height="2142" alt="image" src="https://github.com/user-attachments/assets/3c911b66-63c7-45a3-bd3a-5ad94dc29b59" />

<img width="1201" height="608" alt="Screen Shot 2025-08-20 at 6 32 00 PM" src="https://github.com/user-attachments/assets/11e879a5-9eee-4a06-8654-3dafaa58e3ac" /> <br/>

**After status approval: Aug 19th "test past event"**
<img width="960" height="2142" alt="image" src="https://github.com/user-attachments/assets/845079b8-ccbf-4fe2-8c5d-534732bb9a79" />

<img width="1203" height="608" alt="Screen Shot 2025-08-20 at 6 35 52 PM" src="https://github.com/user-attachments/assets/626bf34e-2594-4427-bd22-a9875b1c04d5" />
